### PR TITLE
[WJ-792] Update wikidot-normalize to support international form.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 
 [dependencies]
-deunicode = "1"
 lazy_static = "1"
 maplit = "1"
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ lazy_static = "1"
 maplit = "1"
 regex = "1"
 trim-in-place = "0.1"
+unicode-normalization = "0.1"
 
 [dev-dependencies]
 str-macro = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 keywords = ["wikidot", "normal", "nuscp"]
 exclude = [".gitignore", ".travis.yml"]
 
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,6 @@
 //! * Any trailing forward slashes are stripped.
 //! * Finally, any leading, trailing, or multiple dashes are removed.
 
-extern crate deunicode;
-
 #[macro_use]
 extern crate lazy_static;
 extern crate maplit;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,9 @@
 //! A library to provide Wikidot-compatible string normalization.
 //!
 //! Wikidot ensures all names of pages subscribe to a particular pattern.
-//! Essentially, only the characters `:`, `a-z`, `0-9`, and `-` can be outputted.
+//! Essentially, only alphanumeric characters, and `:`, `-`, and `_` are permitted.
 //!
-//! * Any uppercase ASCII characters are made lowercase, and any characters outside
+//! * Any uppercase characters are case folded, and any characters outside
 //! the above set are collapsed into dashes. Multiple dashes or forward slashes are compressed
 //! into a single instance.
 //! * Any trailing forward slashes are stripped.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,10 @@ extern crate regex;
 #[macro_use]
 extern crate str_macro;
 extern crate trim_in_place;
+extern crate unicode_normalization;
 
 mod normal;
 mod underscore;
+mod unicode;
 
 pub use self::normal::normalize;

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -12,7 +12,7 @@
  */
 
 use crate::underscore::replace_underscores;
-use crate::unicode::normalize_nfkc;
+use crate::unicode::{casefold, normalize_nfkc};
 use regex::Regex;
 use trim_in_place::TrimInPlace;
 
@@ -57,8 +57,10 @@ pub fn normalize(text: &mut String) {
     // Normalize to unicode NFKC.
     normalize_nfkc(text);
 
-    // Perform case folding. This effectively lowercases all the characters.
-    // TODO
+    // Perform case folding.
+    // This lowercases all the characters in the string, based on
+    // unicode codepoint data.
+    casefold(text);
 
     // Replace all characters not allowed in normal form.
     replace_in_place(text, &*NON_NORMAL, "-");

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -12,9 +12,7 @@
  */
 
 use crate::underscore::replace_underscores;
-use deunicode::deunicode_with_tofu;
 use regex::Regex;
-use std::mem;
 use trim_in_place::TrimInPlace;
 
 macro_rules! regex {
@@ -54,10 +52,6 @@ pub fn normalize(text: &mut String) {
     if text.starts_with('/') {
         text.replace_range(..1, "");
     }
-
-    // Transform latin-like characters into ASCII.
-    // See ascii module for more details.
-    transform_ascii(text);
 
     // Lowercase all ASCII alphabetic characters.
     // Combined with the previous transformation this should
@@ -108,12 +102,6 @@ fn replace_in_place(text: &mut String, regex: &Regex, replace_with: &str) {
         let range = get_range(captures);
         text.replace_range(range, replace_with);
     }
-}
-
-fn transform_ascii(text: &mut String) {
-    let mut result = deunicode_with_tofu(text, "\u{FFFD}");
-
-    mem::swap(text, &mut result);
 }
 
 #[test]

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -34,7 +34,7 @@ regex!(LEADING_OR_TRAILING_COLON, r"(^:)|(:$)");
 /// Converts an arbitrary string into Wikidot normalized form.
 ///
 /// This will convert non-alphanumeric characters to dashes and
-/// makes it lowercase.
+/// case fold it.
 ///
 /// Examples:
 /// * `Big Cheese Horace` -> `big-cheese-horace`

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -12,6 +12,7 @@
  */
 
 use crate::underscore::replace_underscores;
+use crate::unicode::normalize_nfkc;
 use regex::Regex;
 use trim_in_place::TrimInPlace;
 
@@ -23,7 +24,7 @@ macro_rules! regex {
     };
 }
 
-regex!(NON_NORMAL, r"[^a-z0-9\-:_]");
+regex!(NON_NORMAL, r"[^\p{L}\p{N}\-:_]");
 regex!(LEADING_OR_TRAILING_DASHES, r"(^-+)|(-+$)");
 regex!(MULTIPLE_DASHES, r"-{2,}");
 regex!(MULTIPLE_COLONS, r":{2,}");
@@ -53,10 +54,11 @@ pub fn normalize(text: &mut String) {
         text.replace_range(..1, "");
     }
 
-    // Lowercase all ASCII alphabetic characters.
-    // Combined with the previous transformation this should
-    // lowercase every character we care about (and permit in normal form anyways).
-    text.make_ascii_lowercase();
+    // Normalize to unicode NFKC.
+    normalize_nfkc(text);
+
+    // Perform case folding. This effectively lowercases all the characters.
+    // TODO
 
     // Replace all characters not allowed in normal form.
     replace_in_place(text, &*NON_NORMAL, "-");

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -148,7 +148,7 @@ fn test_normalize() {
     check!("Template_", "template");
     check!("Template__", "template");
     check!(" <[ TEST ]> ", "test");
-    check!("ÄÀ-áö ðñæ_þß*řƒŦ", "aa-ao-dnae-thss-rft");
+    check!("ÄÀ-áö ðñæ_þß*řƒŦ", "äà-áö-ðñæ_þß-řƒŧ");
     check!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", "");
     check!("Component:image block", "component:image-block");
     check!("fragment:scp-4447-2", "fragment:scp-4447-2");

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -149,6 +149,9 @@ fn test_normalize() {
     check!("Template__", "template");
     check!(" <[ TEST ]> ", "test");
     check!("ÄÀ-áö ðñæ_þß*řƒŦ", "äà-áö-ðñæ_þß-řƒŧ");
+    check!("Site-五", "site-五");
+    check!("ᒥᐢᑕᓇᐢᑯᐍᐤ--1", "ᒥᐢᑕᓇᐢᑯᐍᐤ-1");
+    check!("🚗A‱B⁜C", "a-b-c");
     check!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", "");
     check!("Component:image block", "component:image-block");
     check!("fragment:scp-4447-2", "fragment:scp-4447-2");

--- a/src/unicode.rs
+++ b/src/unicode.rs
@@ -1,0 +1,21 @@
+/*
+ * unicode.rs
+ *
+ * wikidot-normalize - Library to provide Wikidot-compatible normalization.
+ * Copyright (c) 2019 Ammon Smith
+ *
+ * wikidot-normalize is available free of charge under the terms of the MIT
+ * License. You are free to redistribute and/or modify it under those
+ * terms. It is distributed in the hopes that it will be useful, but
+ * WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+ *
+ */
+
+use std::mem;
+use unicode_normalization::UnicodeNormalization;
+
+pub fn normalize_nfkc(text: &mut String) {
+    let mut normalized = text.nfkc().collect();
+
+    mem::swap(text, &mut normalized);
+}

--- a/src/unicode.rs
+++ b/src/unicode.rs
@@ -19,3 +19,13 @@ pub fn normalize_nfkc(text: &mut String) {
 
     mem::swap(text, &mut normalized);
 }
+
+pub fn casefold(text: &mut String) {
+    let mut folded = String::new();
+
+    for ch in text.chars() {
+        folded.extend(ch.to_lowercase());
+    }
+
+    mem::swap(text, &mut folded);
+}


### PR DESCRIPTION
This modifies this crate to support non-ASCII letters, as described in [WJ-792](https://scuttle.atlassian.net/browse/WJ-792).

See also https://github.com/scpwiki/wikijump/pull/388