### PR TITLE
[WJ-355] Multiple categories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 keywords = ["wikidot", "normal", "nuscp"]
 exclude = [".gitignore", ".travis.yml"]
 
-version = "0.9.2"
+version = "0.10.0"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 

--- a/src/category.rs
+++ b/src/category.rs
@@ -1,0 +1,58 @@
+/*
+ * category.rs
+ *
+ * wikidot-normalize - Library to provide Wikidot-compatible normalization.
+ * Copyright (c) 2019-2022 Ammon Smith
+ *
+ * wikidot-normalize is available free of charge under the terms of the MIT
+ * License. You are free to redistribute and/or modify it under those
+ * terms. It is distributed in the hopes that it will be useful, but
+ * WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+ *
+ */
+
+pub fn merge_multi_categories(text: &mut String) {
+    let mut indices = vec![];
+    let mut first = true;
+
+    // Find all colons except the last
+    for (idx, ch) in text.char_indices().rev() {
+        if ch != ':' {
+            continue;
+        }
+
+        if first {
+            first = false;
+            continue;
+        }
+
+        indices.push(idx);
+    }
+
+    // Replace all colons with dashes
+    for idx in indices {
+        text.replace_range(idx..idx + 1, "-");
+    }
+}
+
+#[test]
+fn test_multi_category() {
+    macro_rules! check {
+        ($input:expr, $expected:expr $(,)?) => {{
+            let mut text = str!($input);
+            merge_multi_categories(&mut text);
+            assert_eq!(
+                text,
+                $expected,
+                "Merged multiple categories doesn't match expected",
+            );
+        }};
+    }
+
+    check!("", "");
+    check!("alpha", "alpha");
+    check!("alpha:beta", "alpha:beta");
+    check!("alpha:beta:gamma", "alpha-beta:gamma");
+    check!("alpha:beta:gamma:delta", "alpha-beta-gamma:delta");
+    check!("alpha:beta:gamma:delta:epsilon", "alpha-beta-gamma-delta:epsilon");
+}

--- a/src/category.rs
+++ b/src/category.rs
@@ -57,4 +57,12 @@ fn test_multi_category() {
         "alpha:beta:gamma:delta:epsilon",
         "alpha-beta-gamma-delta:epsilon",
     );
+    check!(
+        "alpha:beta:gamma:delta:epsilon:zeta",
+        "alpha-beta-gamma-delta-epsilon:zeta",
+    );
+    check!(
+        "alpha:beta:gamma:delta:epsilon:zeta:eta",
+        "alpha-beta-gamma-delta-epsilon-zeta:eta",
+    );
 }

--- a/src/category.rs
+++ b/src/category.rs
@@ -42,8 +42,7 @@ fn test_multi_category() {
             let mut text = str!($input);
             merge_multi_categories(&mut text);
             assert_eq!(
-                text,
-                $expected,
+                text, $expected,
                 "Merged multiple categories doesn't match expected",
             );
         }};
@@ -54,5 +53,8 @@ fn test_multi_category() {
     check!("alpha:beta", "alpha:beta");
     check!("alpha:beta:gamma", "alpha-beta:gamma");
     check!("alpha:beta:gamma:delta", "alpha-beta-gamma:delta");
-    check!("alpha:beta:gamma:delta:epsilon", "alpha-beta-gamma-delta:epsilon");
+    check!(
+        "alpha:beta:gamma:delta:epsilon",
+        "alpha-beta-gamma-delta:epsilon",
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ extern crate str_macro;
 extern crate trim_in_place;
 extern crate unicode_normalization;
 
+mod category;
 mod normal;
 mod underscore;
 mod unicode;

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -140,6 +140,9 @@ fn test_normalize() {
     check!("$100 is a lot of money", "100-is-a-lot-of-money");
     check!("snake_case", "snake-case");
     check!("long__snake__case", "long-snake-case");
+    check!("snake-_dash", "snake-dash");
+    check!("snake_-dash", "snake-dash");
+    check!("snake_-_dash", "snake-dash");
     check!("_template", "_template");
     check!("_template_", "_template");
     check!("__template", "_template");

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -230,3 +230,25 @@ fn test_normalize() {
         "protected:fragment:_template",
     );
 }
+
+#[test]
+fn test_multi_category() {
+    macro_rules! check {
+        ($input:expr, $expected:expr $(,)?) => {{
+            let mut text = str!($input);
+            merge_multi_categories(&mut text);
+            assert_eq!(
+                text,
+                $expected,
+                "Merged multiple categories doesn't match expected",
+            );
+        }};
+    }
+
+    check!("", "");
+    check!("alpha", "alpha");
+    check!("alpha:beta", "alpha:beta");
+    check!("alpha:beta:gamma", "alpha-beta:gamma");
+    check!("alpha:beta:gamma:delta", "alpha-beta-gamma:delta");
+    check!("alpha:beta:gamma:delta:epsilon", "alpha-beta-gamma-delta:epsilon");
+}

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -84,6 +84,10 @@ pub fn normalize(text: &mut String) {
     // Remove any leading or trailing colons.
     replace_in_place(text, &*LEADING_OR_TRAILING_COLON, "");
 
+    // Replace all prior colons with dashes, to make an "extra long category".
+    // See https://scuttle.atlassian.net/browse/WJ-355
+    merge_multi_categories(text);
+
     // Remove explicit _default category, if it exists.
     if text.starts_with("_default:") {
         text.replace_range(..9, "");
@@ -105,6 +109,30 @@ fn replace_in_place(text: &mut String, regex: &Regex, replace_with: &str) {
     while let Some(captures) = regex.captures(text) {
         let range = get_range(captures);
         text.replace_range(range, replace_with);
+    }
+}
+
+fn merge_multi_categories(text: &mut String) {
+    let mut indices = Vec::new();
+    let mut first = true;
+
+    // Find all colons except the last
+    for (idx, ch) in text.char_indices().rev() {
+        if ch != ':' {
+            continue;
+        }
+
+        if first {
+            first = false;
+            continue;
+        }
+
+        indices.push(idx);
+    }
+
+    // Replace all colons with dashes
+    for idx in indices {
+        text.replace_range(idx..idx + 1, "-");
     }
 }
 

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -138,6 +138,7 @@ fn test_normalize() {
     check!("some,Page", "some-page");
     check!("End of Death Hub", "end-of-death-hub");
     check!("$100 is a lot of money", "100-is-a-lot-of-money");
+    check!("$100 is a lot of money!", "100-is-a-lot-of-money");
     check!("snake_case", "snake-case");
     check!("long__snake__case", "long-snake-case");
     check!("snake-_dash", "snake-dash");

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -65,6 +65,10 @@ pub fn normalize(text: &mut String) {
     // Replace all characters not allowed in normal form.
     replace_in_place(text, &*NON_NORMAL, "-");
 
+    // Replace all prior colons with dashes, to make an "extra long category".
+    // See https://scuttle.atlassian.net/browse/WJ-355
+    merge_multi_categories(text);
+
     // Replace non-leading underscores with dashes.
     //
     // Permits names like "_template" or "category:_template".
@@ -83,10 +87,6 @@ pub fn normalize(text: &mut String) {
 
     // Remove any leading or trailing colons.
     replace_in_place(text, &*LEADING_OR_TRAILING_COLON, "");
-
-    // Replace all prior colons with dashes, to make an "extra long category".
-    // See https://scuttle.atlassian.net/browse/WJ-355
-    merge_multi_categories(text);
 
     // Remove explicit _default category, if it exists.
     if text.starts_with("_default:") {

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -168,8 +168,8 @@ fn test_normalize() {
     check!("fragment:scp-4447-2", "fragment:scp-4447-2");
     check!("fragment::scp-4447-2", "fragment:scp-4447-2");
     check!("FRAGMENT:SCP-4447 (2)", "fragment:scp-4447-2");
-    check!("protected_:fragment_:page", "protected:fragment:page");
-    check!("protected:_fragment_:page", "protected:_fragment:page");
+    check!("protected_:fragment_:page", "protected-fragment:page");
+    check!("protected:_fragment_:page", "protected-fragment:page");
     check!("fragment:_template", "fragment:_template");
     check!("fragment:__template", "fragment:_template");
     check!("fragment:_template_", "fragment:_template");
@@ -188,26 +188,30 @@ fn test_normalize() {
     check!("/_default::_template", "_template");
     check!(
         "protected:fragment:_template",
-        "protected:fragment:_template",
+        "protected-fragment:_template",
     );
     check!(
         "protected:fragment:__template",
-        "protected:fragment:_template",
+        "protected-fragment:_template",
     );
     check!(
         "protected:fragment:_template_",
-        "protected:fragment:_template",
+        "protected-fragment:_template",
     );
     check!(
         "protected:fragment::_template",
-        "protected:fragment:_template",
+        "protected-fragment:_template",
     );
     check!(
         "protected::fragment:_template",
-        "protected:fragment:_template",
+        "protected-fragment:_template",
     );
     check!(
         "protected::fragment::_template",
-        "protected:fragment:_template",
+        "protected-fragment:_template",
+    );
+    check!(
+        "protected:archived:fragment:page",
+        "protected-archived-fragment:page",
     );
 }

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -11,6 +11,7 @@
  *
  */
 
+use crate::category::merge_multi_categories;
 use crate::underscore::replace_underscores;
 use crate::unicode::{casefold, normalize_nfkc};
 use regex::Regex;
@@ -112,30 +113,6 @@ fn replace_in_place(text: &mut String, regex: &Regex, replace_with: &str) {
     }
 }
 
-fn merge_multi_categories(text: &mut String) {
-    let mut indices = Vec::new();
-    let mut first = true;
-
-    // Find all colons except the last
-    for (idx, ch) in text.char_indices().rev() {
-        if ch != ':' {
-            continue;
-        }
-
-        if first {
-            first = false;
-            continue;
-        }
-
-        indices.push(idx);
-    }
-
-    // Replace all colons with dashes
-    for idx in indices {
-        text.replace_range(idx..idx + 1, "-");
-    }
-}
-
 #[test]
 fn test_normalize() {
     macro_rules! check {
@@ -229,26 +206,4 @@ fn test_normalize() {
         "protected::fragment::_template",
         "protected:fragment:_template",
     );
-}
-
-#[test]
-fn test_multi_category() {
-    macro_rules! check {
-        ($input:expr, $expected:expr $(,)?) => {{
-            let mut text = str!($input);
-            merge_multi_categories(&mut text);
-            assert_eq!(
-                text,
-                $expected,
-                "Merged multiple categories doesn't match expected",
-            );
-        }};
-    }
-
-    check!("", "");
-    check!("alpha", "alpha");
-    check!("alpha:beta", "alpha:beta");
-    check!("alpha:beta:gamma", "alpha-beta:gamma");
-    check!("alpha:beta:gamma:delta", "alpha-beta-gamma:delta");
-    check!("alpha:beta:gamma:delta:epsilon", "alpha-beta-gamma-delta:epsilon");
 }


### PR DESCRIPTION
This resolves [WJ-355](https://scuttle.atlassian.net/browse/WJ-355), which calls for a redirect based on "multiple categories". Wikidot doesn't actually support multiple categories for a slug at once, so the syntax is confusing. We do not support it either because it isn't widely used in Wikidot, the work of "properly" implementing the concept of multiple categories is comparatively large, and it's ill-defined.

For instance, this will normalize a slug like `archived:protected:page` to `archived-protected:page`. This allows both an actual category to exist there, that logically encapsulates what it means to have "multiple categories", and avoids the weird ambiguities surrounding multiple colons (where does the category end, where does the page begin, etc).